### PR TITLE
Fix UHD stream recv argument order

### DIFF
--- a/run_inference.py
+++ b/run_inference.py
@@ -135,7 +135,10 @@ def capture_from_sdr(num_samps: int, rate: float, freq: float, gain: float) -> t
     rx_stream = usrp.get_rx_stream(stream_args)
     md = uhd.types.RXMetadata()
     buff = np.zeros((num_samps,), dtype=np.complex64)
-    rx_stream.recv([buff], num_samps, md)
+    timeout = num_samps / rate + 0.1
+    num_rx_samps = rx_stream.recv([buff], md, timeout=timeout)
+    if num_rx_samps != num_samps:
+        buff = buff[:num_rx_samps]
     iq_np = np.vstack((buff.real, buff.imag))
     return torch.from_numpy(iq_np).float()
 


### PR DESCRIPTION
## Summary
- fix argument order when receiving SDR samples
- handle short reads and add timeout based on requested sample count

## Testing
- `python -m py_compile run_inference.py`
- `python run_inference.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch` *(fails: packages could not be fully downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a7c968588321af6dfbff6b7d71f3