### PR TITLE
Align inference spectrogram with training

### DIFF
--- a/run_inference.py
+++ b/run_inference.py
@@ -325,7 +325,19 @@ def main() -> None:
     model.to(args.device)
     model.eval()
 
-    transform = transform_spectrogram(device=args.device)
+    # Use the exact same spectrogram configuration as during training to avoid
+    # any mismatch between the training and inference pipelines.
+    transform = transform_spectrogram(
+        device=args.device,
+        n_fft=1024,
+        win_length=1024,
+        hop_length=1024,
+        window_fn=torch.hann_window,
+        power=None,
+        normalized=False,
+        center=False,
+        onesided=False,
+    )
 
     if args.source == "file":
         if not args.file:


### PR DESCRIPTION
## Summary
- Ensure inference uses the same torchaudio-based spectrogram parameters as training to avoid preprocessing mismatches

## Testing
- `python -m py_compile run_inference.py`
- Attempted `python run_inference.py --help` *(fails: No module named 'torch')*
- `pip install torch --index-url https://download.pytorch.org/whl/cpu` *(fails: ProxyError 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b9870bb3d8832188c8a222311d226e