### PR TITLE
Add antenna flag and tune_request for SDR inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,28 @@ The classification report for all SNR levels is stored as `acc.csv` in the same 
 
 The accuracy per SNR level is stored in a file `acc_per_SNR.csv` in the same folder.
 
+## Run inference on live SDR or IQ files
+The script `run_inference.py` can process previously recorded IQ data or stream
+directly from a UHD-compatible SDR. When using an SDR, the antenna port can be
+selected via the new `--antenna` flag. Typical antenna names for a B210 are
+`RX2` and `TX/RX`; the default is `TX/RX`.
+
+Example command:
+
+```bash
+python run_inference.py \
+    --weights results/experiments/model.pth \
+    --source sdr \
+    --rate 14e6 \
+    --freq 2.4e9 \
+    --gain 30 \
+    --antenna RX2
+```
+
+The USRP B210 accepts RX gain values from roughly 0 to 76 dB. In many indoor
+scenarios, settings between 20 and 40 dB provide a good balance between noise
+and sensitivity.
+
 ## Tensorboard
 During training several metrics are logged to tensorboard. To start tensorboard run the following command:
 ```bash

--- a/run_inference_tui.py
+++ b/run_inference_tui.py
@@ -107,10 +107,11 @@ def run(stdscr, args):
     rate = float(_get_input(stdscr, len(models) + 2, "Sample rate", "14e6"))
     freq = float(_get_input(stdscr, len(models) + 3, "Center frequency", "2.4e9"))
     gain = float(_get_input(stdscr, len(models) + 4, "Gain", "0"))
+    antenna = _get_input(stdscr, len(models) + 5, "Antenna", "TX/RX")
     chunk_size = int(
         _get_input(
             stdscr,
-            len(models) + 5,
+            len(models) + 6,
             "Chunk size",
             str(DEFAULT_CHUNK_SIZE),
         )
@@ -154,7 +155,7 @@ def run(stdscr, args):
     model.eval()
 
     transform = transform_spectrogram(device=args.device)
-    iq_iter = iq_chunks_from_sdr(chunk_size, rate, freq, gain)
+    iq_iter = iq_chunks_from_sdr(chunk_size, rate, freq, gain, antenna)
 
     height, width = stdscr.getmaxyx()
     prob_lines = len(class_names) + 2


### PR DESCRIPTION
## Summary
- add `--antenna` CLI option to select SDR RF port
- use `uhd.libpyuhd.types.tune_request` when tuning from the SDR capture loop
- document antenna selection and typical gain values

## Testing
- `python -m py_compile run_inference.py run_inference_tui.py`
- `pip install torch --index-url https://download.pytorch.org/whl/cpu` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68baab1b04e083218f507b2ace2b0992