### PR TITLE
docs: add inference argument details

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,36 @@ This repository was cloned from [the original authors!](!https://github.com/sglu
 #### `run_inference.py`
 Run inference on IQ samples from a file or SDR device. Supply the model weights and choose `--source` as `file` or `sdr`.
 
+**Arguments:**
+- `--weights PATH` – path to model weights (.pth) (required)
+- `--source {sdr,file}` – input source (required)
+- `--file PATH` – IQ data file when `--source` is `file`
+- `--num_samps N` – number of IQ samples to capture (default `1024*1024`)
+- `--chunk_size N` – samples per inference chunk (default `1024*1024`)
+- `--continuous` – continuously read from the SDR
+- `--rate`, `--freq`, `--gain`, `--antenna` – SDR configuration
+- `--device DEVICE` – computation device (e.g., `cpu`, `cuda`)
+- `--num_classes N` – override number of output classes
+- `--class-names LIST/FILE` – comma-separated list or text file of class names
+
 #### `run_inference_tui.py`
 Provides a curses-based text interface that prompts for model and radio settings and continuously displays detection probabilities alongside an FFT graph.
 
+**Arguments:**
+- `--models-dir DIR` – directory containing `.pth` files (default `.`)
+- `--device DEVICE` – computation device (default `cpu`)
+
 #### `run_inference_qt.py`
 Starts a PyQt5 GUI with a live spectrogram and prediction readout. Works with SDR streams or IQ files.
+
+**Arguments:**
+- `--weights PATH` – path to model weights (.pth) (required)
+- `--source {sdr,file}` – input source (required)
+- `--file PATH` – IQ data file when `--source` is `file`
+- `--num_samps N` – number of IQ samples to capture (default `1024*1024`)
+- `--chunk_size N` – IQ samples per chunk (default `1024*1024`)
+- `--continuous` – continuously read from the SDR
+- `--rate`, `--freq`, `--gain`, `--antenna` – SDR configuration
+- `--device DEVICE` – computation device
+- `--spectrogram-size WIDTH HEIGHT` – spectrogram image size in pixels (default `800 800`)
 


### PR DESCRIPTION
## Summary
- document CLI arguments for `run_inference.py`
- document CLI arguments for `run_inference_tui.py`
- document CLI arguments for `run_inference_qt.py`

## Testing
- `python run_inference.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*
- `python run_inference_tui.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*
- `python run_inference_qt.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch` *(operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_68bec55babdc832197c0904fd2254c89