### PR TITLE
Add optional spectrogram preview

### DIFF
--- a/run_inference.py
+++ b/run_inference.py
@@ -7,6 +7,7 @@ from collections import deque
 import numpy as np
 import torch
 import torch.nn.functional as F
+import matplotlib.pyplot as plt
 from lib import model_VGG2D
 from load_dataset import transform_spectrogram
 
@@ -321,6 +322,11 @@ def main() -> None:
             "Defaults to names from class_stats.csv if present."
         ),
     )
+    parser.add_argument(
+        "--show-spectrogram",
+        action="store_true",
+        help="Display an updating spectrogram preview for each processed chunk",
+    )
     args = parser.parse_args()
 
     state = torch.load(args.weights, map_location=args.device)
@@ -401,6 +407,10 @@ def main() -> None:
         center=False,
         onesided=False,
     )
+    img = None
+    if args.show_spectrogram:
+        plt.ion()
+        fig, ax = plt.subplots()
 
     if args.source == "file":
         if not args.file:
@@ -420,7 +430,19 @@ def main() -> None:
     try:
         for i, iq in enumerate(iq_iter):
             iq = iq.to(args.device)
-            spec = transform(iq).unsqueeze(0)  # (1, 2, 1024, 1024)
+            spec = transform(iq)
+            if args.show_spectrogram:
+                spec_mag = spec.pow(2).sum(dim=0).sqrt().cpu().numpy()
+                if img is None:
+                    img = ax.imshow(spec_mag, origin="lower", aspect="auto")
+                    ax.set_title("Spectrogram")
+                    plt.show(block=False)
+                else:
+                    img.set_data(spec_mag)
+                    img.set_clim(spec_mag.min(), spec_mag.max())
+                fig.canvas.draw()
+                fig.canvas.flush_events()
+            spec = spec.unsqueeze(0)  # (1, 2, 1024, 1024)
 
             with torch.no_grad():
                 logits = model(spec)


### PR DESCRIPTION
## Summary
- Allow enabling a live spectrogram preview via `--show-spectrogram`
- Update preview window with each processed chunk using matplotlib

## Testing
- `python -m py_compile run_inference.py`
- `python run_inference.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install --quiet numpy matplotlib torch --index-url https://download.pytorch.org/whl/cpu` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68c29a4685ec8321bfb05cf31289709f