### PR TITLE
Add npy int16 flag to Qt inference script

### DIFF
--- a/run_inference_qt.py
+++ b/run_inference_qt.py
@@ -111,6 +111,14 @@ def main() -> None:
     parser.add_argument("--weights", required=True, help="Path to model weights (.pth)")
     parser.add_argument("--source", choices=["sdr", "file"], required=True, help="Input source")
     parser.add_argument("--file", help="Path to IQ file (.npy, .pt or .c16)")
+    parser.add_argument(
+        "--npy-int16",
+        action="store_true",
+        help=(
+            "Treat .npy files as raw interleaved int16 IQ samples "
+            "recorded with stream_args('fc32','sc16')"
+        ),
+    )
     parser.add_argument("--num_samps", type=int, default=1024 * 1024, help="Number of IQ samples to capture")
     parser.add_argument("--chunk_size", type=int, default=1024 * 1024, help="IQ samples per chunk")
     parser.add_argument("--rate", type=float, default=14e6, help="SDR sample rate")
@@ -178,7 +186,9 @@ def main() -> None:
     if args.source == "file":
         if not args.file:
             raise ValueError("--file path required when source is 'file'")
-        iq_iter = run_inference.iq_chunks_from_file(args.file, args.chunk_size)
+        iq_iter = run_inference.iq_chunks_from_file(
+            args.file, args.chunk_size, args.npy_int16
+        )
     else:
         if args.continuous:
             iq_iter = run_inference.iq_chunks_from_sdr(


### PR DESCRIPTION
## Summary
- add `--npy-int16` flag to `run_inference_qt.py`
- forward flag to IQ file loader so raw int16 `.npy` captures are handled

## Testing
- `python -m py_compile run_inference_qt.py`
- `python run_inference_qt.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c40fb1b450832199fc12dd7e65e6c3